### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ as well as anonymous authentication. Note that
 Firebase also supports authentication with email & password and custom auth tokens.
 You can read the full [iOS authentication guide here](https://www.firebase.com/docs/ios/guide/user-auth.html).
 
-This demo requires that [Cocoapods](https://cocoapods.org/) is installed.
+This demo requires that [CocoaPods](https://cocoapods.org/) is installed.
 
 Running the Demo
 ----------------


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
