### PR TITLE
Fix ACAccount error

### DIFF
--- a/Login Demo/TwitterAuthHelper.h
+++ b/Login Demo/TwitterAuthHelper.h
@@ -7,6 +7,7 @@
 //
 
 #import <Firebase/Firebase.h>
+@import Accounts;
 
 @interface TwitterAuthHelper : NSObject
 


### PR DESCRIPTION
Fix issue #16 iOS getting several errors around "ACAccount" and "Bad receiver type int'

@katfang 
